### PR TITLE
NQuads.php: made blank node regex more flexible

### DIFF
--- a/NQuads.php
+++ b/NQuads.php
@@ -78,7 +78,7 @@ class NQuads implements QuadSerializerInterface, QuadParserInterface
     {
         // define partial regexes
         $iri = '(?:<([^>]*)>)';
-        $bnode = '(_:(?:[A-Za-z0-9]+))';
+        $bnode = '(_:(?:[A-Za-z0-9\_\.\-]+))';
         $plain = '"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"';
         $datatype = "\\^\\^$iri";
         $language = '(?:@([a-z]+(?:-[a-z0-9]+)*))';


### PR DESCRIPTION
As far as I understand https://www.w3.org/TR/n-quads/#BNodes, blank node labels in NQuads can include `-`, `.` and `_` too. Specification requires these characters not being at the beginning of the label, but this regex is not structured to check that anyway.