### PR TITLE
Restore remote-doc tests

### DIFF
--- a/Test/TestManifestIterator.php
+++ b/Test/TestManifestIterator.php
@@ -105,33 +105,6 @@ class TestManifestIterator implements \Iterator
             $options->{'expandContext'} = $this->directory . $options->{'expandContext'};
         }
 
-        /*
-         * This code in the if-clause fixes at least the following tests of the W3C test suite:
-         *
-         * - remote-doc-manifest.jsonld#t0011
-         *
-         * Tests failed because context was not provided properly. The following code extracts
-         * the context file and loads it into the options object. Later on the value of
-         * expandContext is being merged into the active context.
-         *
-         * For further information: https://github.com/lanthaler/JsonLD/pull/113#issuecomment-3426479583
-         */
-        if (
-            isset($options->httpLink)
-            && is_string($options->httpLink)
-            && 1 === preg_match('/<(.*?)>/', $options->httpLink, $match)
-            && isset($match[1])
-        ) {
-            // TODO use a local file path
-            $linkToContextFile = 'http://localhost:8080/Test/json-ld-test-suite/'.$match[1];
-            $content = file_get_contents($linkToContextFile);
-            if (false === $content) {
-                throw new Exception('Could not context from URL: '. $linkToContextFile);
-            }
-
-            $options->expandContext = json_decode($content, false);
-        }
-
         $test = array(
             'name'    => $test->{'name'},
             'test'    => $test,

--- a/Test/W3CTestSuiteTest.php
+++ b/Test/W3CTestSuiteTest.php
@@ -47,7 +47,7 @@ class W3CTestSuiteTest extends JsonTestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$process = new Process(['php', '-S', 'localhost:8080']);
+        self::$process = new Process(['php', '-S', 'localhost:8080', 'Test/router.php']);
         self::$process->start();
 
         // do not stop server automatically after a certain amount of time
@@ -192,83 +192,10 @@ class W3CTestSuiteTest extends JsonTestCase
     #[DataProvider('remoteDocumentLoadingProvider')]
     public function testRemoteDocumentLoading($name, $test, $options)
     {
-        /*
-         * There are a few failing tests and its not clear at the moment, if its because
-         * the library is buggy or the test related files were. Therefore skipping certain tests
-         * but leaving a clear error message.
-         *
-         * For instance, the related manifest file references for t0007 the following files:
-         * - remote-doc-0007-in.jsonld
-         *
-         * But these files dont exist, neither in https://github.com/w3c/json-ld-api/tree/main/tests/remote-doc
-         * nor https://github.com/json-ld/tests.
-         *
-         * For more information: https://github.com/lanthaler/JsonLD/pull/113
-         */
-        $brokenTests = [
-            'Load JSON-LD through 301 redirect' => 'remote-doc: t0005',
-            'Load JSON-LD through 303 redirect' => 'remote-doc: t0006',
-            'Load JSON-LD through 307 redirect' => 'remote-doc: t0007',
-        ];
-        if (in_array($name, array_keys($brokenTests))) {
-            $msg = 'Manifest file references an input file which NEVER existed! Broken test name: '.$brokenTests[$name];
-            $this->markTestSkipped($msg);
-        }
-
-        if ('Multiple context link headers' === $name) {
-            $msg = 'Test remote-doc-manifest.jsonld#t0012 is broken.';
-            $msg .= ' It is expected that the test throws an exception because of multiple httpLink entries,';
-            $msg .= ' but that is not happening. I can not think of a serious way to implement/"trigger" this behavior.';
-            $this->markTestSkipped($msg);
-        }
-
         if (in_array('jld:NegativeEvaluationTest', $test->{'@type'})) {
             $expect = $test->{'expect'};
-
-            /*
-             * Adapts expected error message for the test > remote-doc-manifest.jsonld #t0004
-             *
-             * Here is the related test output without the following code:
-             *
-             * 1) ML\JsonLD\Test\W3CTestSuiteTest::testRemoteDocumentLoading with data set
-             * "http://localhost:8080/Test/json-ld-test-suite/remote-doc-manifest.jsonld#t0004"
-             * ('loading an unknown type raise...failed', stdClass Object (...), stdClass Object (...))
-             *
-             * Failed asserting that exception message 'Syntax error, malformed JSON.' contains 'loading document failed'.
-             *
-             * phpvfscomposer:///var/www/html/vendor/phpunit/phpunit/phpunit:106
-             */
-            if ('loading an unknown type raises loading document failed' === $name) {
-                $expect = 'Syntax error, malformed JSON.';
-            }
-
             $this->expectException(JsonLdException::class);
-
-            /*
-             * Adapts behavior for test remote-doc-manifest.jsonld #t0008
-             *
-             * The library put time-depended information in the error message which prevents us
-             * from comparing it to a static string. Instead we look for a certain part in the
-             * error message.
-             *
-             * Here is the related test output without the following code:
-             *
-             * 1) ML\JsonLD\Test\W3CTestSuiteTest::testRemoteDocumentLoading with data set
-             * "http://localhost:8080/Test/json-ld-test-suite/remote-doc-manifest.jsonld#t0008"
-             * ('Non-existant file (404)', stdClass Object (...), stdClass Object ())
-             *
-             * Failed asserting that exception message 'Unable to load the remote document
-             * "http://localhost:8080/Test/json-ld-test-suite/remote-doc-0008-in.jsonld"
-             * (near ["HTTP/1.1 404 Not Found","Server: nginx","Date: Tue, 21 Oct 2025 12:30:48 GMT",
-             * "Content-Type: text/html","Content-Length: 1022","Connection: close",
-             * "Last-Modified: Mon, 24 Feb 2014 19:45:05 GMT","ETag: \"3fe-4f32c354a1240\"",
-             * "Accept-Ranges: bytes"]).' contains 'loading document failed'.
-             */
-            if ('Non-existant file (404)' === $name) {
-                $this->expectExceptionMessageMatches('/Unable to load the remote document/');
-            } else {
-                $this->expectExceptionMessage($expect);
-            }
+            $this->expectExceptionMessage($expect);
         } else {
             $expected = json_decode($this->replaceBaseUrl(file_get_contents(self::$basedir . $test->{'expect'})));
         }

--- a/Test/json-ld-test-suite/remote-doc-0009-out.jsonld
+++ b/Test/json-ld-test-suite/remote-doc-0009-out.jsonld
@@ -1,4 +1,4 @@
 [{
-  "@id": "http://localhost:8080/test-suite/tests/remote-doc-0009-in.jsonld",
+  "@id": "http://localhost:8080/Test/json-ld-test-suite/remote-doc-0009-in.jsonld",
   "http://example/0009/term": [{"@value": "value1"}]
 }]

--- a/Test/json-ld-test-suite/remote-doc-0010-out.jsonld
+++ b/Test/json-ld-test-suite/remote-doc-0010-out.jsonld
@@ -1,4 +1,4 @@
 [{
-  "@id": "http://localhost:8080/test-suite/tests/remote-doc-0010-in.json",
+  "@id": "http://localhost:8080/Test/json-ld-test-suite/remote-doc-0010-in.json",
   "http://example/vocab#term": [{"@value": "value"}]
 }]

--- a/Test/json-ld-test-suite/remote-doc-0011-out.jsonld
+++ b/Test/json-ld-test-suite/remote-doc-0011-out.jsonld
@@ -1,4 +1,4 @@
 [{
-  "@id": "http://localhost:8080/test-suite/tests/remote-doc-0011-in.jldt",
+  "@id": "http://localhost:8080/Test/json-ld-test-suite/remote-doc-0011-in.jldt",
   "http://example/vocab#term": [{"@value": "value"}]
 }]

--- a/Test/json-ld-test-suite/remote-doc-manifest.jsonld
+++ b/Test/json-ld-test-suite/remote-doc-manifest.jsonld
@@ -39,7 +39,7 @@
         "contentType": "application/jldTest"
       },
       "input": "remote-doc-0004-in.jldte",
-      "expect": "loading document failed"
+      "expect": "Invalid media type"
     }, {
       "@id": "#t0005",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -79,7 +79,38 @@
       "name": "Non-existant file (404)",
       "purpose": "Loading a non-existant file raises loading document failed error",
       "input": "remote-doc-0008-in.jsonld",
-      "expect": "loading document failed"
+      "expect": "Unable to load the remote document"
+    }, {
+      "@id": "#t0009",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "load JSON-LD document with link",
+      "purpose": "If a context is specified in a link header, it is not used for JSON-LD.",
+      "option": {
+        "httpLink": "<remote-doc-0009-context.jsonld>; rel=\"http://www.w3.org/ns/json-ld#context\""
+      },
+      "input": "remote-doc-0009-in.jsonld",
+      "expect": "remote-doc-0009-out.jsonld"
+    }, {
+      "@id": "#t0010",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "load JSON document with link",
+      "purpose": "If a context is specified in a link header, it is used for JSON.",
+      "option": {
+        "httpLink": "<remote-doc-0010-context.jsonld>; rel=\"http://www.w3.org/ns/json-ld#context\""
+      },
+      "input": "remote-doc-0010-in.json",
+      "expect": "remote-doc-0010-out.jsonld"
+    }, {
+      "@id": "#t0011",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "load JSON document with extension-type with link",
+      "purpose": "If a context is specified in a link header, it is used for a JSON extension type.",
+      "input": "remote-doc-0011-in.jldt",
+      "option": {
+        "contentType": "application/jldTest+json",
+        "httpLink": "<remote-doc-0011-context.jsonld>; rel=\"http://www.w3.org/ns/json-ld#context\""
+      },
+      "expect": "remote-doc-0011-out.jsonld"
     }, {
       "@id": "#t0012",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -92,7 +123,7 @@
         ]
       },
       "input": "remote-doc-0012-in.json",
-      "expect": "multiple context link headers"
+      "expect": "multiple contexts in HTTP Link headers"
     }
   ]
 }

--- a/Test/router.php
+++ b/Test/router.php
@@ -1,0 +1,42 @@
+<?php
+if ($_SERVER['REQUEST_URI'] === '/Test/json-ld-test-suite/remote-doc-0005-in.jsonld') {
+    header('Location: http://localhost:8080/Test/json-ld-test-suite/remote-doc-0001-in.jsonld');
+    http_response_code(301);
+    return;
+} elseif ($_SERVER['REQUEST_URI'] === '/Test/json-ld-test-suite/remote-doc-0006-in.jsonld') {
+    header('Location: http://localhost:8080/Test/json-ld-test-suite/remote-doc-0001-in.jsonld');
+    http_response_code(303);
+    return;
+} elseif ($_SERVER['REQUEST_URI'] === '/Test/json-ld-test-suite/remote-doc-0007-in.jsonld') {
+    header('Location: http://localhost:8080/Test/json-ld-test-suite/remote-doc-0001-in.jsonld');
+    http_response_code(307);
+    return;
+}
+
+
+if ($_SERVER['REQUEST_URI'] === '/Test/json-ld-test-suite/remote-doc-0009-in.jsonld') {
+    header('Link: <remote-doc-0009-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"');
+} elseif ($_SERVER['REQUEST_URI'] === '/Test/json-ld-test-suite/remote-doc-0010-in.json') {
+    header('Link: <remote-doc-0010-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"');
+} elseif ($_SERVER['REQUEST_URI'] === '/Test/json-ld-test-suite/remote-doc-0011-in.jldt') {
+    header('Link: <remote-doc-0011-context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"');
+} elseif ($_SERVER['REQUEST_URI'] === '/Test/json-ld-test-suite/remote-doc-0012-in.json') {
+    header('Link: <remote-doc-0012-context1.jsonld>; rel="http://www.w3.org/ns/json-ld#context"');
+    header('Link: <remote-doc-0012-context2.jsonld>; rel="http://www.w3.org/ns/json-ld#context"', false);
+}
+
+if (pathinfo($_SERVER['SCRIPT_FILENAME'])['extension'] === 'jsonld') {
+    header('Content-Type: application/ld+json');
+    readfile($_SERVER['SCRIPT_FILENAME']);
+} elseif (pathinfo($_SERVER['SCRIPT_FILENAME'])['extension'] === 'json') {
+    header('Content-Type: application/json');
+    readfile($_SERVER['SCRIPT_FILENAME']);
+} elseif (pathinfo($_SERVER['SCRIPT_FILENAME'])['extension'] === 'jldt') {
+    header('Content-Type: application/jldTest+json');
+    readfile($_SERVER['SCRIPT_FILENAME']);
+} elseif (pathinfo($_SERVER['SCRIPT_FILENAME'])['extension'] === 'jldte') {
+    header('Content-Type: application/jldTest');
+    readfile($_SERVER['SCRIPT_FILENAME']);
+} else {
+    return false;
+}


### PR DESCRIPTION
This removes the skips and special cases from the test suite for the remote-doc test cases 0005, 0006, 0007, 0009, 0010, 0011, and 0012.

These all relied on particular headers being returned in the response, and the test suite previously had a .htaccess used to produce the proper headers when the test suite was hosted with Apache. This change adds a "router" script for the PHP built-in webserver that now is hosting the test cases to produce the same relevant headers.

Tests 0005, 0006, and 0007 needed Location headers as they were intended to test redirects. Tests 0009, 0010, 0011, and 0012 tested various behaviors with the Link header.

A few small changes to the test suite data were necessary to account for the changed URL and drift in the library's exception messages, but none of these are substantive changes.

One note: this change on its own will lead to some test failures as it exposes an issue with the FileGetContentsLoader (see #5).

(fix #4)